### PR TITLE
Replace unidecode with anyascii

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,13 @@ requirements:
     - pip
   run:
     - python >=3.6
+    - anyascii
     - astroid >=2.7
     - jinja2
     - pyyaml
     - sphinx >=3.0
     - sphinxcontrib-golangdomain
     - sphinxcontrib-dotnetdomain
-    - unidecode
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sphinx-autoapi" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5b5c58064214d5a846c9c81d23f00990a64654b9bca10213231db54a241bc50f
+  sha256: fbadb96e79020d6b0ec45d888517bf816d6b587a2d340fbe1ec31135e300a6c8
 
 build:
   noarch: python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Requirements of the upstream package changed: unidecode was replaced with anyascii. See https://github.com/readthedocs/sphinx-autoapi/commit/0a557fc95eb1130efb9459d403dfbc30c003024c